### PR TITLE
Add PIX key registration and withdrawal pages

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -22,6 +22,8 @@ import Depositar from "./pages/Depositar";
 import NotFound from "./pages/NotFound";
 import ComoFunciona from "./pages/ComoFunciona";
 import PlanosBeneficios from "./pages/PlanosBeneficios";
+import CadastroChavePix from "./pages/CadastroChavePix";
+import Saque from "./pages/Saque";
 
 const queryClient = new QueryClient();
 export default function App() {
@@ -54,6 +56,8 @@ export default function App() {
             <Route path="/saldo" element={<Saldo />} />
             <Route path="/depositar" element={<Depositar />} />
             <Route path="/planos-beneficios" element={<PlanosBeneficios />} />
+            <Route path="/cadastro-chave-pix" element={<CadastroChavePix />} />
+            <Route path="/saque" element={<Saque />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/client/lib/pix.ts
+++ b/client/lib/pix.ts
@@ -27,10 +27,16 @@ export function savePixKeys(keys: PixKey[]) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(keys));
 }
 
-export function addPixKey(key: Omit<PixKey, "id" | "createdAt"> & { id?: string; createdAt?: string }): PixKey[] {
+export function addPixKey(
+  key: Omit<PixKey, "id" | "createdAt"> & { id?: string; createdAt?: string },
+): PixKey[] {
   const keys = loadPixKeys();
   const newKey: PixKey = {
-    id: key.id ?? (typeof crypto !== "undefined" && "randomUUID" in crypto ? crypto.randomUUID() : String(Date.now() + Math.random())),
+    id:
+      key.id ??
+      (typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : String(Date.now() + Math.random())),
     createdAt: key.createdAt ?? new Date().toISOString(),
     type: key.type,
     value: key.value.trim(),
@@ -47,9 +53,12 @@ export function deletePixKey(id: string): PixKey[] {
 }
 
 export function generateRandomPixKey(): string {
-  if (typeof crypto !== "undefined" && "randomUUID" in crypto) return crypto.randomUUID();
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto)
+    return crypto.randomUUID();
   // Fallback simple random string
-  return Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
+  return (
+    Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2)
+  );
 }
 
 export function validatePixValue(type: PixKeyType, value: string): boolean {
@@ -68,7 +77,12 @@ export function validatePixValue(type: PixKeyType, value: string): boolean {
     case "celular": {
       const digits = v.replace(/\D/g, "");
       // BR: 10 or 11 digits (without country), allow 12/13 with 55 country code
-      return digits.length === 10 || digits.length === 11 || digits.length === 12 || digits.length === 13;
+      return (
+        digits.length === 10 ||
+        digits.length === 11 ||
+        digits.length === 12 ||
+        digits.length === 13
+      );
     }
     default:
       return false;

--- a/client/lib/pix.ts
+++ b/client/lib/pix.ts
@@ -1,0 +1,76 @@
+export type PixKeyType = "aleatoria" | "email" | "cpf_cnpj" | "celular";
+
+export interface PixKey {
+  id: string;
+  type: PixKeyType;
+  value: string;
+  createdAt: string; // ISO string
+}
+
+const STORAGE_KEY = "pixKeys";
+
+export function loadPixKeys(): PixKey[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as PixKey[];
+    if (!Array.isArray(parsed)) return [];
+    return parsed;
+  } catch {
+    return [];
+  }
+}
+
+export function savePixKeys(keys: PixKey[]) {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(keys));
+}
+
+export function addPixKey(key: Omit<PixKey, "id" | "createdAt"> & { id?: string; createdAt?: string }): PixKey[] {
+  const keys = loadPixKeys();
+  const newKey: PixKey = {
+    id: key.id ?? (typeof crypto !== "undefined" && "randomUUID" in crypto ? crypto.randomUUID() : String(Date.now() + Math.random())),
+    createdAt: key.createdAt ?? new Date().toISOString(),
+    type: key.type,
+    value: key.value.trim(),
+  };
+  const updated = [newKey, ...keys];
+  savePixKeys(updated);
+  return updated;
+}
+
+export function deletePixKey(id: string): PixKey[] {
+  const keys = loadPixKeys().filter((k) => k.id !== id);
+  savePixKeys(keys);
+  return keys;
+}
+
+export function generateRandomPixKey(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) return crypto.randomUUID();
+  // Fallback simple random string
+  return Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
+}
+
+export function validatePixValue(type: PixKeyType, value: string): boolean {
+  const v = value.trim();
+  switch (type) {
+    case "aleatoria":
+      return v.length >= 10; // UUID or random token
+    case "email": {
+      const re = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/i;
+      return re.test(v);
+    }
+    case "cpf_cnpj": {
+      const digits = v.replace(/\D/g, "");
+      return digits.length === 11 || digits.length === 14;
+    }
+    case "celular": {
+      const digits = v.replace(/\D/g, "");
+      // BR: 10 or 11 digits (without country), allow 12/13 with 55 country code
+      return digits.length === 10 || digits.length === 11 || digits.length === 12 || digits.length === 13;
+    }
+    default:
+      return false;
+  }
+}

--- a/client/pages/CadastroChavePix.tsx
+++ b/client/pages/CadastroChavePix.tsx
@@ -136,11 +136,6 @@ export default function CadastroChavePix() {
                     tipo === "celular" ? "+55 (DDD) 9XXXX-XXXX" :
                     "Chave aleatória"
                   } value={valor} onChange={(e) => setValor(e.target.value)} disabled={tipo === "aleatoria"} />
-                  {tipo === "aleatoria" && (
-                    <Button type="button" variant="outline" onClick={handleGerar} className="shrink-0">
-                      <RefreshCw className="w-4 h-4 mr-2" /> Gerar
-                    </Button>
-                  )}
                 </div>
               </div>
 

--- a/client/pages/CadastroChavePix.tsx
+++ b/client/pages/CadastroChavePix.tsx
@@ -7,7 +7,7 @@ import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useToast } from "@/hooks/use-toast";
-import { KeyRound, Mail, Smartphone, IdCard, Zap, ArrowLeft, PlusCircle, RefreshCw, Trash2 } from "lucide-react";
+import { KeyRound, Mail, Smartphone, IdCard, Zap, ArrowLeft, PlusCircle, Trash2 } from "lucide-react";
 import { PixKey, PixKeyType, addPixKey, deletePixKey, generateRandomPixKey, loadPixKeys, validatePixValue } from "@/lib/pix";
 
 export default function CadastroChavePix() {

--- a/client/pages/CadastroChavePix.tsx
+++ b/client/pages/CadastroChavePix.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { useToast } from "@/hooks/use-toast";
+import { KeyRound, Mail, Smartphone, IdCard, Zap, ArrowLeft, PlusCircle, RefreshCw, Trash2 } from "lucide-react";
+import { PixKey, PixKeyType, addPixKey, deletePixKey, generateRandomPixKey, loadPixKeys, validatePixValue } from "@/lib/pix";
+
+export default function CadastroChavePix() {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const [tipo, setTipo] = useState<PixKeyType>("aleatoria");
+  const [valor, setValor] = useState("");
+  const [chaves, setChaves] = useState<PixKey[]>([]);
+
+  useEffect(() => {
+    setChaves(loadPixKeys());
+  }, []);
+
+  useEffect(() => {
+    if (tipo === "aleatoria" && !valor) {
+      setValor(generateRandomPixKey());
+    }
+  }, [tipo]);
+
+  const iconePorTipo = useMemo(() => {
+    switch (tipo) {
+      case "email":
+        return <Mail className="w-4 h-4" />;
+      case "cpf_cnpj":
+        return <IdCard className="w-4 h-4" />;
+      case "celular":
+        return <Smartphone className="w-4 h-4" />;
+      default:
+        return <KeyRound className="w-4 h-4" />;
+    }
+  }, [tipo]);
+
+  const handleSalvar = () => {
+    if (!validatePixValue(tipo, valor)) {
+      toast({
+        title: "Dados inválidos",
+        description: "Verifique o valor informado para a chave PIX.",
+      });
+      return;
+    }
+    const lista = addPixKey({ type: tipo, value: valor });
+    setChaves(lista);
+    toast({ title: "Chave PIX salva", description: "Sua chave foi cadastrada com sucesso." });
+    setValor(tipo === "aleatoria" ? generateRandomPixKey() : "");
+  };
+
+  const handleGerar = () => setValor(generateRandomPixKey());
+
+  const removerChave = (id: string) => {
+    const lista = deletePixKey(id);
+    setChaves(lista);
+    toast({ title: "Chave removida" });
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b">
+        <div className="container mx-auto px-6 py-4">
+          <div className="flex items-center justify-between">
+            <Link to="/" className="flex items-center space-x-2">
+              <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center">
+                <Zap className="w-5 h-5 text-white" />
+              </div>
+              <span className="text-xl font-bold text-gray-900">TalentHub</span>
+            </Link>
+
+            <div className="flex items-center space-x-4">
+              <Button variant="ghost" size="sm" onClick={() => navigate(-1)}>
+                <ArrowLeft className="w-4 h-4 mr-2" />
+                Voltar
+              </Button>
+              <Avatar>
+                <AvatarImage src="/placeholder.svg" />
+                <AvatarFallback>CL</AvatarFallback>
+              </Avatar>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="container mx-auto px-6 py-8 max-w-2xl">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">Cadastrar Chave PIX</h1>
+          <p className="text-gray-600">Cadastre uma nova chave para saques e recebimentos.</p>
+        </div>
+
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center">
+                <KeyRound className="w-5 h-5 mr-2" /> Nova chave
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <Label>Tipo de chave</Label>
+                <RadioGroup value={tipo} onValueChange={(v) => setTipo(v as PixKeyType)} className="grid grid-cols-2 gap-3 mt-2">
+                  <label className="flex items-center space-x-2 p-3 border rounded-lg cursor-pointer">
+                    <RadioGroupItem value="aleatoria" id="t-aleatoria" />
+                    <span>Chave aleatória</span>
+                  </label>
+                  <label className="flex items-center space-x-2 p-3 border rounded-lg cursor-pointer">
+                    <RadioGroupItem value="email" id="t-email" />
+                    <span>E-mail</span>
+                  </label>
+                  <label className="flex items-center space-x-2 p-3 border rounded-lg cursor-pointer">
+                    <RadioGroupItem value="cpf_cnpj" id="t-cpf" />
+                    <span>CPF/CNPJ</span>
+                  </label>
+                  <label className="flex items-center space-x-2 p-3 border rounded-lg cursor-pointer">
+                    <RadioGroupItem value="celular" id="t-celular" />
+                    <span>Celular</span>
+                  </label>
+                </RadioGroup>
+              </div>
+
+              <div>
+                <Label htmlFor="valor">Valor da chave</Label>
+                <div className="flex items-center mt-1 space-x-2">
+                  <div className="w-9 h-9 rounded-md bg-gray-100 flex items-center justify-center text-gray-600">
+                    {iconePorTipo}
+                  </div>
+                  <Input id="valor" placeholder={
+                    tipo === "email" ? "seuemail@dominio.com" :
+                    tipo === "cpf_cnpj" ? "Somente números (CPF ou CNPJ)" :
+                    tipo === "celular" ? "+55 (DDD) 9XXXX-XXXX" :
+                    "Chave aleatória"
+                  } value={valor} onChange={(e) => setValor(e.target.value)} disabled={tipo === "aleatoria"} />
+                  {tipo === "aleatoria" && (
+                    <Button type="button" variant="outline" onClick={handleGerar} className="shrink-0">
+                      <RefreshCw className="w-4 h-4 mr-2" /> Gerar
+                    </Button>
+                  )}
+                </div>
+              </div>
+
+              <Button className="w-full h-12 text-lg" onClick={handleSalvar}>
+                <PlusCircle className="w-5 h-5 mr-2" /> Salvar chave
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Minhas chaves</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {chaves.length === 0 ? (
+                <p className="text-sm text-gray-600">Você ainda não possui chaves cadastradas.</p>
+              ) : (
+                <div className="space-y-3">
+                  {chaves.map((c) => (
+                    <div key={c.id} className="flex items-center justify-between p-3 border rounded-lg bg-white">
+                      <div className="flex items-center space-x-3">
+                        <div className="w-9 h-9 rounded-md bg-gray-100 flex items-center justify-center text-gray-600">
+                          {c.type === "email" ? <Mail className="w-4 h-4" /> : c.type === "cpf_cnpj" ? <IdCard className="w-4 h-4" /> : c.type === "celular" ? <Smartphone className="w-4 h-4" /> : <KeyRound className="w-4 h-4" />}
+                        </div>
+                        <div>
+                          <p className="font-medium text-gray-900">{c.value}</p>
+                          <p className="text-xs text-gray-500 capitalize">{c.type.replace("_", "/")}</p>
+                        </div>
+                      </div>
+                      <Button variant="ghost" size="icon" onClick={() => removerChave(c.id)}>
+                        <Trash2 className="w-4 h-4" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/pages/CadastroChavePix.tsx
+++ b/client/pages/CadastroChavePix.tsx
@@ -7,8 +7,25 @@ import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useToast } from "@/hooks/use-toast";
-import { KeyRound, Mail, Smartphone, IdCard, Zap, ArrowLeft, PlusCircle, Trash2 } from "lucide-react";
-import { PixKey, PixKeyType, addPixKey, deletePixKey, generateRandomPixKey, loadPixKeys, validatePixValue } from "@/lib/pix";
+import {
+  KeyRound,
+  Mail,
+  Smartphone,
+  IdCard,
+  Zap,
+  ArrowLeft,
+  PlusCircle,
+  Trash2,
+} from "lucide-react";
+import {
+  PixKey,
+  PixKeyType,
+  addPixKey,
+  deletePixKey,
+  generateRandomPixKey,
+  loadPixKeys,
+  validatePixValue,
+} from "@/lib/pix";
 
 export default function CadastroChavePix() {
   const navigate = useNavigate();
@@ -50,7 +67,10 @@ export default function CadastroChavePix() {
     }
     const lista = addPixKey({ type: tipo, value: valor });
     setChaves(lista);
-    toast({ title: "Chave PIX salva", description: "Sua chave foi cadastrada com sucesso." });
+    toast({
+      title: "Chave PIX salva",
+      description: "Sua chave foi cadastrada com sucesso.",
+    });
     setValor(tipo === "aleatoria" ? generateRandomPixKey() : "");
   };
 
@@ -90,8 +110,12 @@ export default function CadastroChavePix() {
 
       <div className="container mx-auto px-6 py-8 max-w-2xl">
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">Cadastrar Chave PIX</h1>
-          <p className="text-gray-600">Cadastre uma nova chave para saques e recebimentos.</p>
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">
+            Cadastrar Chave PIX
+          </h1>
+          <p className="text-gray-600">
+            Cadastre uma nova chave para saques e recebimentos.
+          </p>
         </div>
 
         <div className="space-y-6">
@@ -104,7 +128,11 @@ export default function CadastroChavePix() {
             <CardContent className="space-y-4">
               <div>
                 <Label>Tipo de chave</Label>
-                <RadioGroup value={tipo} onValueChange={(v) => setTipo(v as PixKeyType)} className="grid grid-cols-2 gap-3 mt-2">
+                <RadioGroup
+                  value={tipo}
+                  onValueChange={(v) => setTipo(v as PixKeyType)}
+                  className="grid grid-cols-2 gap-3 mt-2"
+                >
                   <label className="flex items-center space-x-2 p-3 border rounded-lg cursor-pointer">
                     <RadioGroupItem value="aleatoria" id="t-aleatoria" />
                     <span>Chave aleatória</span>
@@ -130,12 +158,21 @@ export default function CadastroChavePix() {
                   <div className="w-9 h-9 rounded-md bg-gray-100 flex items-center justify-center text-gray-600">
                     {iconePorTipo}
                   </div>
-                  <Input id="valor" placeholder={
-                    tipo === "email" ? "seuemail@dominio.com" :
-                    tipo === "cpf_cnpj" ? "Somente números (CPF ou CNPJ)" :
-                    tipo === "celular" ? "+55 (DDD) 9XXXX-XXXX" :
-                    "Chave aleatória"
-                  } value={valor} onChange={(e) => setValor(e.target.value)} disabled={tipo === "aleatoria"} />
+                  <Input
+                    id="valor"
+                    placeholder={
+                      tipo === "email"
+                        ? "seuemail@dominio.com"
+                        : tipo === "cpf_cnpj"
+                          ? "Somente números (CPF ou CNPJ)"
+                          : tipo === "celular"
+                            ? "+55 (DDD) 9XXXX-XXXX"
+                            : "Chave aleatória"
+                    }
+                    value={valor}
+                    onChange={(e) => setValor(e.target.value)}
+                    disabled={tipo === "aleatoria"}
+                  />
                 </div>
               </div>
 
@@ -151,21 +188,40 @@ export default function CadastroChavePix() {
             </CardHeader>
             <CardContent>
               {chaves.length === 0 ? (
-                <p className="text-sm text-gray-600">Você ainda não possui chaves cadastradas.</p>
+                <p className="text-sm text-gray-600">
+                  Você ainda não possui chaves cadastradas.
+                </p>
               ) : (
                 <div className="space-y-3">
                   {chaves.map((c) => (
-                    <div key={c.id} className="flex items-center justify-between p-3 border rounded-lg bg-white">
+                    <div
+                      key={c.id}
+                      className="flex items-center justify-between p-3 border rounded-lg bg-white"
+                    >
                       <div className="flex items-center space-x-3">
                         <div className="w-9 h-9 rounded-md bg-gray-100 flex items-center justify-center text-gray-600">
-                          {c.type === "email" ? <Mail className="w-4 h-4" /> : c.type === "cpf_cnpj" ? <IdCard className="w-4 h-4" /> : c.type === "celular" ? <Smartphone className="w-4 h-4" /> : <KeyRound className="w-4 h-4" />}
+                          {c.type === "email" ? (
+                            <Mail className="w-4 h-4" />
+                          ) : c.type === "cpf_cnpj" ? (
+                            <IdCard className="w-4 h-4" />
+                          ) : c.type === "celular" ? (
+                            <Smartphone className="w-4 h-4" />
+                          ) : (
+                            <KeyRound className="w-4 h-4" />
+                          )}
                         </div>
                         <div>
                           <p className="font-medium text-gray-900">{c.value}</p>
-                          <p className="text-xs text-gray-500 capitalize">{c.type.replace("_", "/")}</p>
+                          <p className="text-xs text-gray-500 capitalize">
+                            {c.type.replace("_", "/")}
+                          </p>
                         </div>
                       </div>
-                      <Button variant="ghost" size="icon" onClick={() => removerChave(c.id)}>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => removerChave(c.id)}
+                      >
                         <Trash2 className="w-4 h-4" />
                       </Button>
                     </div>

--- a/client/pages/Saldo.tsx
+++ b/client/pages/Saldo.tsx
@@ -133,13 +133,15 @@ export default function Saldo() {
                   Depositar
                 </Button>
               </Link>
-              <Button
-                variant="outline"
-                className="flex-1 border-white text-white hover:bg-blue-600"
-              >
-                <Minus className="w-4 h-4 mr-2" />
-                Sacar
-              </Button>
+              <Link to="/saque" className="flex-1">
+                <Button
+                  variant="outline"
+                  className="w-full border-white text-white hover:bg-blue-600"
+                >
+                  <Minus className="w-4 h-4 mr-2" />
+                  Sacar
+                </Button>
+              </Link>
             </div>
           </CardContent>
         </Card>

--- a/client/pages/Saque.tsx
+++ b/client/pages/Saque.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { useToast } from "@/hooks/use-toast";
+import { Wallet, ArrowLeft, Zap, DollarSign, KeyRound, Info } from "lucide-react";
+import { PixKey, loadPixKeys } from "@/lib/pix";
+
+const TAXA_FIXA = 0; // R$
+const TAXA_PERCENTUAL = 0; // %
+
+export default function Saque() {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const [chaves, setChaves] = useState<PixKey[]>([]);
+  const [chaveId, setChaveId] = useState<string>("");
+  const [valor, setValor] = useState<string>("");
+
+  useEffect(() => {
+    const lista = loadPixKeys();
+    setChaves(lista);
+    if (lista.length > 0) setChaveId(lista[0].id);
+  }, []);
+
+  const chaveSelecionada = useMemo(() => chaves.find((c) => c.id === chaveId), [chaves, chaveId]);
+
+  const valorNumber = parseFloat(valor) || 0;
+  const taxaPercentualValor = (TAXA_PERCENTUAL / 100) * valorNumber;
+  const taxaTotal = TAXA_FIXA + taxaPercentualValor;
+  const valorLiquido = Math.max(0, valorNumber - taxaTotal);
+
+  const solicitarSaque = () => {
+    if (!chaveSelecionada) {
+      toast({ title: "Selecione uma chave PIX" });
+      return;
+    }
+    if (valorNumber <= 0) {
+      toast({ title: "Informe um valor válido" });
+      return;
+    }
+    toast({
+      title: "Saque solicitado",
+      description: `Você receberá R$ ${valorLiquido.toLocaleString("pt-BR", { minimumFractionDigits: 2 })} na chave selecionada.`,
+    });
+    navigate("/saldo");
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b">
+        <div className="container mx-auto px-6 py-4">
+          <div className="flex items-center justify-between">
+            <Link to="/" className="flex items-center space-x-2">
+              <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center">
+                <Zap className="w-5 h-5 text-white" />
+              </div>
+              <span className="text-xl font-bold text-gray-900">TalentHub</span>
+            </Link>
+
+            <div className="flex items-center space-x-4">
+              <Button variant="ghost" size="sm" onClick={() => navigate(-1)}>
+                <ArrowLeft className="w-4 h-4 mr-2" />
+                Voltar
+              </Button>
+              <Avatar>
+                <AvatarImage src="/placeholder.svg" />
+                <AvatarFallback>CL</AvatarFallback>
+              </Avatar>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="container mx-auto px-6 py-8 max-w-2xl">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">Solicitar Saque</h1>
+          <p className="text-gray-600">Escolha sua chave PIX, informe o valor e confira as taxas.</p>
+        </div>
+
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center">
+                <KeyRound className="w-5 h-5 mr-2" /> Chave PIX
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {chaves.length === 0 ? (
+                <div className="p-4 border rounded-lg bg-yellow-50 text-yellow-900">
+                  Você ainda não tem chaves cadastradas. <Link to="/cadastro-chave-pix" className="underline font-medium">Cadastrar chave PIX</Link>
+                </div>
+              ) : (
+                <div>
+                  <Label>Selecionar chave</Label>
+                  <Select value={chaveId} onValueChange={setChaveId}>
+                    <SelectTrigger className="mt-1">
+                      <SelectValue placeholder="Selecione uma chave" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {chaves.map((c) => (
+                        <SelectItem key={c.id} value={c.id}>
+                          {c.value}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+              <div>
+                <Link to="/cadastro-chave-pix">
+                  <Button variant="outline" className="mt-2">Cadastrar nova chave</Button>
+                </Link>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center">
+                <DollarSign className="w-5 h-5 mr-2" /> Valor do saque
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <Label htmlFor="valor">Digite o valor</Label>
+                <div className="relative mt-1">
+                  <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500">R$</span>
+                  <Input id="valor" type="number" min="1" step="0.01" className="pl-10 text-lg" placeholder="0,00" value={valor} onChange={(e) => setValor(e.target.value)} />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {valorNumber > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Resumo do Saque</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <div className="flex justify-between">
+                  <span className="text-gray-600">Valor solicitado</span>
+                  <span className="font-medium">R$ {valorNumber.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-600">Taxa fixa</span>
+                  <span className="text-red-600">- R$ {TAXA_FIXA.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-600">Taxa percentual ({TAXA_PERCENTUAL}%)</span>
+                  <span className="text-red-600">- R$ {taxaPercentualValor.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}</span>
+                </div>
+                <hr />
+                <div className="flex justify-between text-lg font-semibold">
+                  <span>Valor a ser creditado</span>
+                  <span className="text-green-600">R$ {valorLiquido.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}</span>
+                </div>
+                <div className="flex items-start space-x-2 p-3 bg-blue-50 rounded-lg">
+                  <Info className="w-4 h-4 text-blue-600 mt-0.5" />
+                  <p className="text-sm text-blue-900">As taxas são aplicadas ao valor solicitado e o líquido será enviado para a chave selecionada.</p>
+                </div>
+                <Button className="w-full h-12 text-lg" onClick={solicitarSaque} disabled={!chaveSelecionada || valorNumber <= 0}>
+                  <Wallet className="w-5 h-5 mr-2" /> Solicitar saque
+                </Button>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/pages/Saque.tsx
+++ b/client/pages/Saque.tsx
@@ -4,10 +4,23 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useToast } from "@/hooks/use-toast";
-import { Wallet, ArrowLeft, Zap, DollarSign, KeyRound, Info } from "lucide-react";
+import {
+  Wallet,
+  ArrowLeft,
+  Zap,
+  DollarSign,
+  KeyRound,
+  Info,
+} from "lucide-react";
 import { PixKey, loadPixKeys } from "@/lib/pix";
 
 const TAXA_FIXA = 0; // R$
@@ -26,7 +39,10 @@ export default function Saque() {
     if (lista.length > 0) setChaveId(lista[0].id);
   }, []);
 
-  const chaveSelecionada = useMemo(() => chaves.find((c) => c.id === chaveId), [chaves, chaveId]);
+  const chaveSelecionada = useMemo(
+    () => chaves.find((c) => c.id === chaveId),
+    [chaves, chaveId],
+  );
 
   const valorNumber = parseFloat(valor) || 0;
   const taxaPercentualValor = (TAXA_PERCENTUAL / 100) * valorNumber;
@@ -77,8 +93,12 @@ export default function Saque() {
 
       <div className="container mx-auto px-6 py-8 max-w-2xl">
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">Solicitar Saque</h1>
-          <p className="text-gray-600">Escolha sua chave PIX, informe o valor e confira as taxas.</p>
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">
+            Solicitar Saque
+          </h1>
+          <p className="text-gray-600">
+            Escolha sua chave PIX, informe o valor e confira as taxas.
+          </p>
         </div>
 
         <div className="space-y-6">
@@ -91,7 +111,13 @@ export default function Saque() {
             <CardContent className="space-y-3">
               {chaves.length === 0 ? (
                 <div className="p-4 border rounded-lg bg-yellow-50 text-yellow-900">
-                  Você ainda não tem chaves cadastradas. <Link to="/cadastro-chave-pix" className="underline font-medium">Cadastrar chave PIX</Link>
+                  Você ainda não tem chaves cadastradas.{" "}
+                  <Link
+                    to="/cadastro-chave-pix"
+                    className="underline font-medium"
+                  >
+                    Cadastrar chave PIX
+                  </Link>
                 </div>
               ) : (
                 <div>
@@ -112,7 +138,9 @@ export default function Saque() {
               )}
               <div>
                 <Link to="/cadastro-chave-pix">
-                  <Button variant="outline" className="mt-2">Cadastrar nova chave</Button>
+                  <Button variant="outline" className="mt-2">
+                    Cadastrar nova chave
+                  </Button>
                 </Link>
               </div>
             </CardContent>
@@ -128,8 +156,19 @@ export default function Saque() {
               <div>
                 <Label htmlFor="valor">Digite o valor</Label>
                 <div className="relative mt-1">
-                  <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500">R$</span>
-                  <Input id="valor" type="number" min="1" step="0.01" className="pl-10 text-lg" placeholder="0,00" value={valor} onChange={(e) => setValor(e.target.value)} />
+                  <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500">
+                    R$
+                  </span>
+                  <Input
+                    id="valor"
+                    type="number"
+                    min="1"
+                    step="0.01"
+                    className="pl-10 text-lg"
+                    placeholder="0,00"
+                    value={valor}
+                    onChange={(e) => setValor(e.target.value)}
+                  />
                 </div>
               </div>
             </CardContent>
@@ -143,26 +182,55 @@ export default function Saque() {
               <CardContent className="space-y-3">
                 <div className="flex justify-between">
                   <span className="text-gray-600">Valor solicitado</span>
-                  <span className="font-medium">R$ {valorNumber.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}</span>
+                  <span className="font-medium">
+                    R${" "}
+                    {valorNumber.toLocaleString("pt-BR", {
+                      minimumFractionDigits: 2,
+                    })}
+                  </span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-gray-600">Taxa fixa</span>
-                  <span className="text-red-600">- R$ {TAXA_FIXA.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}</span>
+                  <span className="text-red-600">
+                    - R${" "}
+                    {TAXA_FIXA.toLocaleString("pt-BR", {
+                      minimumFractionDigits: 2,
+                    })}
+                  </span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-gray-600">Taxa percentual ({TAXA_PERCENTUAL}%)</span>
-                  <span className="text-red-600">- R$ {taxaPercentualValor.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}</span>
+                  <span className="text-gray-600">
+                    Taxa percentual ({TAXA_PERCENTUAL}%)
+                  </span>
+                  <span className="text-red-600">
+                    - R${" "}
+                    {taxaPercentualValor.toLocaleString("pt-BR", {
+                      minimumFractionDigits: 2,
+                    })}
+                  </span>
                 </div>
                 <hr />
                 <div className="flex justify-between text-lg font-semibold">
                   <span>Valor a ser creditado</span>
-                  <span className="text-green-600">R$ {valorLiquido.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}</span>
+                  <span className="text-green-600">
+                    R${" "}
+                    {valorLiquido.toLocaleString("pt-BR", {
+                      minimumFractionDigits: 2,
+                    })}
+                  </span>
                 </div>
                 <div className="flex items-start space-x-2 p-3 bg-blue-50 rounded-lg">
                   <Info className="w-4 h-4 text-blue-600 mt-0.5" />
-                  <p className="text-sm text-blue-900">As taxas são aplicadas ao valor solicitado e o líquido será enviado para a chave selecionada.</p>
+                  <p className="text-sm text-blue-900">
+                    As taxas são aplicadas ao valor solicitado e o líquido será
+                    enviado para a chave selecionada.
+                  </p>
                 </div>
-                <Button className="w-full h-12 text-lg" onClick={solicitarSaque} disabled={!chaveSelecionada || valorNumber <= 0}>
+                <Button
+                  className="w-full h-12 text-lg"
+                  onClick={solicitarSaque}
+                  disabled={!chaveSelecionada || valorNumber <= 0}
+                >
                   <Wallet className="w-5 h-5 mr-2" /> Solicitar saque
                 </Button>
               </CardContent>

--- a/static/react-cadastro-chave-pix.html
+++ b/static/react-cadastro-chave-pix.html
@@ -13,14 +13,19 @@
         <div class="container mx-auto px-6 py-4">
           <div class="flex items-center justify-between">
             <a href="react-index.html" class="flex items-center space-x-2">
-              <div class="w-8 h-8 bg-primary rounded-lg flex items-center justify-center">
+              <div
+                class="w-8 h-8 bg-primary rounded-lg flex items-center justify-center"
+              >
                 <i data-lucide="zap" class="w-5 h-5 text-white"></i>
               </div>
               <span class="text-xl font-bold text-gray-900">TalentHub</span>
             </a>
 
             <div class="flex items-center space-x-4">
-              <button class="button button-ghost button-sm" onclick="history.back()">
+              <button
+                class="button button-ghost button-sm"
+                onclick="history.back()"
+              >
                 <i data-lucide="arrow-left" class="w-4 h-4 mr-2"></i>
                 Voltar
               </button>
@@ -35,8 +40,12 @@
 
       <div class="container mx-auto px-6 py-8 max-w-2xl">
         <div class="mb-8">
-          <h1 class="text-3xl font-bold text-gray-900 mb-2">Cadastrar Chave PIX</h1>
-          <p class="text-gray-600">Cadastre uma nova chave para saques e recebimentos.</p>
+          <h1 class="text-3xl font-bold text-gray-900 mb-2">
+            Cadastrar Chave PIX
+          </h1>
+          <p class="text-gray-600">
+            Cadastre uma nova chave para saques e recebimentos.
+          </p>
         </div>
 
         <div class="space-y-6">
@@ -51,19 +60,27 @@
               <div>
                 <label class="label">Tipo de chave</label>
                 <div class="grid grid-cols-2 gap-3 mt-2" id="tipoContainer">
-                  <label class="flex items-center space-x-2 p-3 border rounded-lg cursor-pointer">
+                  <label
+                    class="flex items-center space-x-2 p-3 border rounded-lg cursor-pointer"
+                  >
                     <input type="radio" name="tipo" value="aleatoria" checked />
                     <span>Chave aleatória</span>
                   </label>
-                  <label class="flex items-center space-x-2 p-3 border rounded-lg cursor-pointer">
+                  <label
+                    class="flex items-center space-x-2 p-3 border rounded-lg cursor-pointer"
+                  >
                     <input type="radio" name="tipo" value="email" />
                     <span>E-mail</span>
                   </label>
-                  <label class="flex items-center space-x-2 p-3 border rounded-lg cursor-pointer">
+                  <label
+                    class="flex items-center space-x-2 p-3 border rounded-lg cursor-pointer"
+                  >
                     <input type="radio" name="tipo" value="cpf_cnpj" />
                     <span>CPF/CNPJ</span>
                   </label>
-                  <label class="flex items-center space-x-2 p-3 border rounded-lg cursor-pointer">
+                  <label
+                    class="flex items-center space-x-2 p-3 border rounded-lg cursor-pointer"
+                  >
                     <input type="radio" name="tipo" value="celular" />
                     <span>Celular</span>
                   </label>
@@ -73,18 +90,33 @@
               <div>
                 <label for="valor" class="label">Valor da chave</label>
                 <div class="flex items-center mt-1 gap-2">
-                  <div class="w-9 h-9 rounded-md bg-gray-100 flex items-center justify-center text-gray-600">
-                    <i id="iconTipo" data-lucide="key-round" class="w-4 h-4"></i>
+                  <div
+                    class="w-9 h-9 rounded-md bg-gray-100 flex items-center justify-center text-gray-600"
+                  >
+                    <i
+                      id="iconTipo"
+                      data-lucide="key-round"
+                      class="w-4 h-4"
+                    ></i>
                   </div>
-                  <input id="valor" class="input" placeholder="Chave aleatória" />
+                  <input
+                    id="valor"
+                    class="input"
+                    placeholder="Chave aleatória"
+                  />
                 </div>
               </div>
 
-              <button id="salvar" class="button button-primary w-full h-12 text-lg">
+              <button
+                id="salvar"
+                class="button button-primary w-full h-12 text-lg"
+              >
                 <i data-lucide="plus-circle" class="w-5 h-5 mr-2"></i>
                 Salvar chave
               </button>
-              <p id="msg" class="text-sm text-green-700" style="display:none">Chave salva com sucesso.</p>
+              <p id="msg" class="text-sm text-green-700" style="display: none">
+                Chave salva com sucesso.
+              </p>
             </div>
           </div>
 
@@ -94,7 +126,9 @@
             </div>
             <div class="card-content">
               <div id="listaChaves" class="space-y-3"></div>
-              <p id="semChaves" class="text-sm text-gray-600">Você ainda não possui chaves cadastradas.</p>
+              <p id="semChaves" class="text-sm text-gray-600">
+                Você ainda não possui chaves cadastradas.
+              </p>
             </div>
           </div>
         </div>
@@ -108,54 +142,80 @@
 
       function uuid() {
         if (window.crypto && crypto.randomUUID) return crypto.randomUUID();
-        return (Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2));
+        return (
+          Math.random().toString(36).slice(2) +
+          Math.random().toString(36).slice(2)
+        );
       }
 
-      function gerarAleatoria() { return uuid(); }
+      function gerarAleatoria() {
+        return uuid();
+      }
 
       function carregarChaves() {
         try {
           return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
-        } catch { return []; }
+        } catch {
+          return [];
+        }
       }
-      function salvarChaves(chaves) { localStorage.setItem(STORAGE_KEY, JSON.stringify(chaves)); }
+      function salvarChaves(chaves) {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(chaves));
+      }
 
       function validar(tipo, valor) {
         const v = (valor || "").trim();
         if (tipo === "aleatoria") return v.length >= 10;
         if (tipo === "email") return /[^\s@]+@[^\s@]+\.[^\s@]{2,}/i.test(v);
-        if (tipo === "cpf_cnpj") { const d = v.replace(/\D/g,""); return d.length===11 || d.length===14; }
-        if (tipo === "celular") { const d = v.replace(/\D/g,""); return [10,11,12,13].includes(d.length); }
+        if (tipo === "cpf_cnpj") {
+          const d = v.replace(/\D/g, "");
+          return d.length === 11 || d.length === 14;
+        }
+        if (tipo === "celular") {
+          const d = v.replace(/\D/g, "");
+          return [10, 11, 12, 13].includes(d.length);
+        }
         return false;
       }
 
-      const valorInput = document.getElementById('valor');
-      const iconTipo = document.getElementById('iconTipo');
-      const msg = document.getElementById('msg');
+      const valorInput = document.getElementById("valor");
+      const iconTipo = document.getElementById("iconTipo");
+      const msg = document.getElementById("msg");
 
-      function atualizarIcone(tipo){
-        const map = { aleatoria: 'key-round', email: 'mail', cpf_cnpj: 'id-card', celular: 'smartphone' };
-        iconTipo.setAttribute('data-lucide', map[tipo] || 'key-round');
+      function atualizarIcone(tipo) {
+        const map = {
+          aleatoria: "key-round",
+          email: "mail",
+          cpf_cnpj: "id-card",
+          celular: "smartphone",
+        };
+        iconTipo.setAttribute("data-lucide", map[tipo] || "key-round");
         lucide.createIcons();
       }
 
       function renderLista() {
-        const wrap = document.getElementById('listaChaves');
-        const vazio = document.getElementById('semChaves');
+        const wrap = document.getElementById("listaChaves");
+        const vazio = document.getElementById("semChaves");
         const chaves = carregarChaves();
-        wrap.innerHTML = '';
-        if (chaves.length === 0) { vazio.style.display = 'block'; return; } else { vazio.style.display = 'none'; }
-        chaves.forEach(c => {
-          const row = document.createElement('div');
-          row.className = 'flex items-center justify-between p-3 border rounded-lg bg-white';
+        wrap.innerHTML = "";
+        if (chaves.length === 0) {
+          vazio.style.display = "block";
+          return;
+        } else {
+          vazio.style.display = "none";
+        }
+        chaves.forEach((c) => {
+          const row = document.createElement("div");
+          row.className =
+            "flex items-center justify-between p-3 border rounded-lg bg-white";
           row.innerHTML = `
             <div class="flex items-center gap-3">
               <div class="w-9 h-9 rounded-md bg-gray-100 flex items-center justify-center text-gray-600">
-                <i data-lucide="${c.type==='email'?'mail':c.type==='cpf_cnpj'?'id-card':c.type==='celular'?'smartphone':'key-round'}" class="w-4 h-4"></i>
+                <i data-lucide="${c.type === "email" ? "mail" : c.type === "cpf_cnpj" ? "id-card" : c.type === "celular" ? "smartphone" : "key-round"}" class="w-4 h-4"></i>
               </div>
               <div>
                 <p class="font-medium text-gray-900">${c.value}</p>
-                <p class="text-xs text-gray-500">${c.type.replace('_','/')}</p>
+                <p class="text-xs text-gray-500">${c.type.replace("_", "/")}</p>
               </div>
             </div>
             <button class="button button-ghost button-icon" data-id="${c.id}">
@@ -164,10 +224,10 @@
           wrap.appendChild(row);
         });
         lucide.createIcons();
-        wrap.querySelectorAll('button[data-id]').forEach(btn => {
-          btn.addEventListener('click', () => {
-            const id = btn.getAttribute('data-id');
-            const rest = carregarChaves().filter(k => k.id !== id);
+        wrap.querySelectorAll("button[data-id]").forEach((btn) => {
+          btn.addEventListener("click", () => {
+            const id = btn.getAttribute("data-id");
+            const rest = carregarChaves().filter((k) => k.id !== id);
             salvarChaves(rest);
             renderLista();
           });
@@ -177,31 +237,50 @@
       function onTipoChange() {
         const tipo = document.querySelector('input[name="tipo"]:checked').value;
         atualizarIcone(tipo);
-        if (tipo === 'aleatoria') {
+        if (tipo === "aleatoria") {
           valorInput.value = gerarAleatoria();
           valorInput.disabled = true;
-          valorInput.placeholder = 'Chave aleatória';
+          valorInput.placeholder = "Chave aleatória";
         } else {
           valorInput.disabled = false;
-          valorInput.value = '';
-          valorInput.placeholder = tipo === 'email' ? 'seuemail@dominio.com' : tipo === 'cpf_cnpj' ? 'Somente números (CPF ou CNPJ)' : '+55 (DDD) 9XXXX-XXXX';
+          valorInput.value = "";
+          valorInput.placeholder =
+            tipo === "email"
+              ? "seuemail@dominio.com"
+              : tipo === "cpf_cnpj"
+                ? "Somente números (CPF ou CNPJ)"
+                : "+55 (DDD) 9XXXX-XXXX";
         }
       }
 
-      document.querySelectorAll('input[name="tipo"]').forEach(r => r.addEventListener('change', onTipoChange));
+      document
+        .querySelectorAll('input[name="tipo"]')
+        .forEach((r) => r.addEventListener("change", onTipoChange));
       onTipoChange();
 
-      document.getElementById('salvar').addEventListener('click', () => {
+      document.getElementById("salvar").addEventListener("click", () => {
         const tipo = document.querySelector('input[name="tipo"]:checked').value;
         const valor = valorInput.value.trim();
-        if (!validar(tipo, valor)) { alert('Dados inválidos. Verifique o valor informado.'); return; }
+        if (!validar(tipo, valor)) {
+          alert("Dados inválidos. Verifique o valor informado.");
+          return;
+        }
         const lista = carregarChaves();
-        const novo = { id: uuid(), type: tipo, value: valor, createdAt: new Date().toISOString() };
+        const novo = {
+          id: uuid(),
+          type: tipo,
+          value: valor,
+          createdAt: new Date().toISOString(),
+        };
         lista.unshift(novo);
         salvarChaves(lista);
-        msg.style.display = 'block';
-        setTimeout(() => msg.style.display = 'none', 2000);
-        if (tipo === 'aleatoria') { valorInput.value = gerarAleatoria(); } else { valorInput.value = ''; }
+        msg.style.display = "block";
+        setTimeout(() => (msg.style.display = "none"), 2000);
+        if (tipo === "aleatoria") {
+          valorInput.value = gerarAleatoria();
+        } else {
+          valorInput.value = "";
+        }
         renderLista();
       });
 

--- a/static/react-cadastro-chave-pix.html
+++ b/static/react-cadastro-chave-pix.html
@@ -1,0 +1,211 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cadastrar Chave PIX - TalentHub</title>
+    <link rel="stylesheet" href="base-styles.css" />
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+  </head>
+  <body>
+    <div class="min-h-screen bg-gray-50">
+      <header class="bg-white border-b">
+        <div class="container mx-auto px-6 py-4">
+          <div class="flex items-center justify-between">
+            <a href="react-index.html" class="flex items-center space-x-2">
+              <div class="w-8 h-8 bg-primary rounded-lg flex items-center justify-center">
+                <i data-lucide="zap" class="w-5 h-5 text-white"></i>
+              </div>
+              <span class="text-xl font-bold text-gray-900">TalentHub</span>
+            </a>
+
+            <div class="flex items-center space-x-4">
+              <button class="button button-ghost button-sm" onclick="history.back()">
+                <i data-lucide="arrow-left" class="w-4 h-4 mr-2"></i>
+                Voltar
+              </button>
+              <div class="avatar">
+                <img src="placeholder.svg" alt="Avatar" class="avatar-image" />
+                <div class="avatar-fallback">CL</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div class="container mx-auto px-6 py-8 max-w-2xl">
+        <div class="mb-8">
+          <h1 class="text-3xl font-bold text-gray-900 mb-2">Cadastrar Chave PIX</h1>
+          <p class="text-gray-600">Cadastre uma nova chave para saques e recebimentos.</p>
+        </div>
+
+        <div class="space-y-6">
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title flex items-center">
+                <i data-lucide="key-round" class="w-5 h-5 mr-2"></i>
+                Nova chave
+              </h3>
+            </div>
+            <div class="card-content space-y-4">
+              <div>
+                <label class="label">Tipo de chave</label>
+                <div class="grid grid-cols-2 gap-3 mt-2" id="tipoContainer">
+                  <label class="flex items-center space-x-2 p-3 border rounded-lg cursor-pointer">
+                    <input type="radio" name="tipo" value="aleatoria" checked />
+                    <span>Chave aleatória</span>
+                  </label>
+                  <label class="flex items-center space-x-2 p-3 border rounded-lg cursor-pointer">
+                    <input type="radio" name="tipo" value="email" />
+                    <span>E-mail</span>
+                  </label>
+                  <label class="flex items-center space-x-2 p-3 border rounded-lg cursor-pointer">
+                    <input type="radio" name="tipo" value="cpf_cnpj" />
+                    <span>CPF/CNPJ</span>
+                  </label>
+                  <label class="flex items-center space-x-2 p-3 border rounded-lg cursor-pointer">
+                    <input type="radio" name="tipo" value="celular" />
+                    <span>Celular</span>
+                  </label>
+                </div>
+              </div>
+
+              <div>
+                <label for="valor" class="label">Valor da chave</label>
+                <div class="flex items-center mt-1 gap-2">
+                  <div class="w-9 h-9 rounded-md bg-gray-100 flex items-center justify-center text-gray-600">
+                    <i id="iconTipo" data-lucide="key-round" class="w-4 h-4"></i>
+                  </div>
+                  <input id="valor" class="input" placeholder="Chave aleatória" />
+                </div>
+              </div>
+
+              <button id="salvar" class="button button-primary w-full h-12 text-lg">
+                <i data-lucide="plus-circle" class="w-5 h-5 mr-2"></i>
+                Salvar chave
+              </button>
+              <p id="msg" class="text-sm text-green-700" style="display:none">Chave salva com sucesso.</p>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title">Minhas chaves</h3>
+            </div>
+            <div class="card-content">
+              <div id="listaChaves" class="space-y-3"></div>
+              <p id="semChaves" class="text-sm text-gray-600">Você ainda não possui chaves cadastradas.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      lucide.createIcons();
+
+      const STORAGE_KEY = "pixKeys";
+
+      function uuid() {
+        if (window.crypto && crypto.randomUUID) return crypto.randomUUID();
+        return (Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2));
+      }
+
+      function gerarAleatoria() { return uuid(); }
+
+      function carregarChaves() {
+        try {
+          return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+        } catch { return []; }
+      }
+      function salvarChaves(chaves) { localStorage.setItem(STORAGE_KEY, JSON.stringify(chaves)); }
+
+      function validar(tipo, valor) {
+        const v = (valor || "").trim();
+        if (tipo === "aleatoria") return v.length >= 10;
+        if (tipo === "email") return /[^\s@]+@[^\s@]+\.[^\s@]{2,}/i.test(v);
+        if (tipo === "cpf_cnpj") { const d = v.replace(/\D/g,""); return d.length===11 || d.length===14; }
+        if (tipo === "celular") { const d = v.replace(/\D/g,""); return [10,11,12,13].includes(d.length); }
+        return false;
+      }
+
+      const valorInput = document.getElementById('valor');
+      const iconTipo = document.getElementById('iconTipo');
+      const msg = document.getElementById('msg');
+
+      function atualizarIcone(tipo){
+        const map = { aleatoria: 'key-round', email: 'mail', cpf_cnpj: 'id-card', celular: 'smartphone' };
+        iconTipo.setAttribute('data-lucide', map[tipo] || 'key-round');
+        lucide.createIcons();
+      }
+
+      function renderLista() {
+        const wrap = document.getElementById('listaChaves');
+        const vazio = document.getElementById('semChaves');
+        const chaves = carregarChaves();
+        wrap.innerHTML = '';
+        if (chaves.length === 0) { vazio.style.display = 'block'; return; } else { vazio.style.display = 'none'; }
+        chaves.forEach(c => {
+          const row = document.createElement('div');
+          row.className = 'flex items-center justify-between p-3 border rounded-lg bg-white';
+          row.innerHTML = `
+            <div class="flex items-center gap-3">
+              <div class="w-9 h-9 rounded-md bg-gray-100 flex items-center justify-center text-gray-600">
+                <i data-lucide="${c.type==='email'?'mail':c.type==='cpf_cnpj'?'id-card':c.type==='celular'?'smartphone':'key-round'}" class="w-4 h-4"></i>
+              </div>
+              <div>
+                <p class="font-medium text-gray-900">${c.value}</p>
+                <p class="text-xs text-gray-500">${c.type.replace('_','/')}</p>
+              </div>
+            </div>
+            <button class="button button-ghost button-icon" data-id="${c.id}">
+              <i data-lucide="trash-2" class="w-4 h-4"></i>
+            </button>`;
+          wrap.appendChild(row);
+        });
+        lucide.createIcons();
+        wrap.querySelectorAll('button[data-id]').forEach(btn => {
+          btn.addEventListener('click', () => {
+            const id = btn.getAttribute('data-id');
+            const rest = carregarChaves().filter(k => k.id !== id);
+            salvarChaves(rest);
+            renderLista();
+          });
+        });
+      }
+
+      function onTipoChange() {
+        const tipo = document.querySelector('input[name="tipo"]:checked').value;
+        atualizarIcone(tipo);
+        if (tipo === 'aleatoria') {
+          valorInput.value = gerarAleatoria();
+          valorInput.disabled = true;
+          valorInput.placeholder = 'Chave aleatória';
+        } else {
+          valorInput.disabled = false;
+          valorInput.value = '';
+          valorInput.placeholder = tipo === 'email' ? 'seuemail@dominio.com' : tipo === 'cpf_cnpj' ? 'Somente números (CPF ou CNPJ)' : '+55 (DDD) 9XXXX-XXXX';
+        }
+      }
+
+      document.querySelectorAll('input[name="tipo"]').forEach(r => r.addEventListener('change', onTipoChange));
+      onTipoChange();
+
+      document.getElementById('salvar').addEventListener('click', () => {
+        const tipo = document.querySelector('input[name="tipo"]:checked').value;
+        const valor = valorInput.value.trim();
+        if (!validar(tipo, valor)) { alert('Dados inválidos. Verifique o valor informado.'); return; }
+        const lista = carregarChaves();
+        const novo = { id: uuid(), type: tipo, value: valor, createdAt: new Date().toISOString() };
+        lista.unshift(novo);
+        salvarChaves(lista);
+        msg.style.display = 'block';
+        setTimeout(() => msg.style.display = 'none', 2000);
+        if (tipo === 'aleatoria') { valorInput.value = gerarAleatoria(); } else { valorInput.value = ''; }
+        renderLista();
+      });
+
+      renderLista();
+    </script>
+  </body>
+</html>

--- a/static/react-saque.html
+++ b/static/react-saque.html
@@ -1,0 +1,194 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Solicitar Saque - TalentHub</title>
+    <link rel="stylesheet" href="base-styles.css" />
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+  </head>
+  <body>
+    <div class="min-h-screen bg-gray-50">
+      <header class="bg-white border-b">
+        <div class="container mx-auto px-6 py-4">
+          <div class="flex items-center justify-between">
+            <a href="react-index.html" class="flex items-center space-x-2">
+              <div class="w-8 h-8 bg-primary rounded-lg flex items-center justify-center">
+                <i data-lucide="zap" class="w-5 h-5 text-white"></i>
+              </div>
+              <span class="text-xl font-bold text-gray-900">TalentHub</span>
+            </a>
+
+            <div class="flex items-center space-x-4">
+              <button class="button button-ghost button-sm" onclick="history.back()">
+                <i data-lucide="arrow-left" class="w-4 h-4 mr-2"></i>
+                Voltar
+              </button>
+              <div class="avatar">
+                <img src="placeholder.svg" alt="Avatar" class="avatar-image" />
+                <div class="avatar-fallback">CL</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div class="container mx-auto px-6 py-8 max-w-2xl">
+        <div class="mb-8">
+          <h1 class="text-3xl font-bold text-gray-900 mb-2">Solicitar Saque</h1>
+          <p class="text-gray-600">Escolha sua chave PIX, informe o valor e confira as taxas.</p>
+        </div>
+
+        <div class="space-y-6">
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title flex items-center">
+                <i data-lucide="key-round" class="w-5 h-5 mr-2"></i>
+                Chave PIX
+              </h3>
+            </div>
+            <div class="card-content space-y-3">
+              <div id="alertaSemChaves" class="p-4 border rounded-lg bg-yellow-50 text-yellow-900" style="display:none">
+                Você ainda não tem chaves cadastradas. <a href="react-cadastro-chave-pix.html" class="underline font-medium">Cadastrar chave PIX</a>
+              </div>
+              <div>
+                <label class="label">Selecionar chave</label>
+                <select id="selectChave" class="input mt-1"></select>
+              </div>
+              <div>
+                <a href="react-cadastro-chave-pix.html" class="button button-outline mt-2">Cadastrar nova chave</a>
+              </div>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title flex items-center">
+                <i data-lucide="dollar-sign" class="w-5 h-5 mr-2"></i>
+                Valor do saque
+              </h3>
+            </div>
+            <div class="card-content space-y-4">
+              <div>
+                <label for="valor" class="label">Digite o valor</label>
+                <div class="relative mt-1">
+                  <span class="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500">R$</span>
+                  <input id="valor" type="number" min="1" step="0.01" class="input pl-10 text-lg" placeholder="0,00" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="card" id="resumoCard" style="display:none">
+            <div class="card-header">
+              <h3 class="card-title">Resumo do Saque</h3>
+            </div>
+            <div class="card-content space-y-3">
+              <div class="flex justify-between">
+                <span class="text-gray-600">Valor solicitado</span>
+                <span class="font-medium" id="valorSolicitado">R$ 0,00</span>
+              </div>
+              <div class="flex justify-between">
+                <span class="text-gray-600">Taxa fixa</span>
+                <span class="text-red-600" id="taxaFixa">- R$ 0,00</span>
+              </div>
+              <div class="flex justify-between">
+                <span class="text-gray-600">Taxa percentual (<span id="taxaPercLbl">0</span>%)</span>
+                <span class="text-red-600" id="taxaPerc">- R$ 0,00</span>
+              </div>
+              <hr />
+              <div class="flex justify-between text-lg font-semibold">
+                <span>Valor a ser creditado</span>
+                <span class="text-green-600" id="valorLiquido">R$ 0,00</span>
+              </div>
+              <div class="flex items-start gap-2 p-3 bg-blue-50 rounded-lg">
+                <i data-lucide="info" class="w-4 h-4 text-blue-600 mt-0.5"></i>
+                <p class="text-sm text-blue-900">As taxas são aplicadas ao valor solicitado e o líquido será enviado para a chave selecionada.</p>
+              </div>
+              <button id="solicitar" class="button button-primary w-full h-12 text-lg" disabled>
+                <i data-lucide="wallet" class="w-5 h-5 mr-2"></i>
+                Solicitar saque
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      lucide.createIcons();
+      const STORAGE_KEY = 'pixKeys';
+      const TAXA_FIXA = 0;
+      const TAXA_PERCENTUAL = 0;
+
+      function carregarChaves(){ try { return JSON.parse(localStorage.getItem(STORAGE_KEY)) || []; } catch { return []; } }
+
+      function formatar(valor){ return `R$ ${valor.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}`; }
+
+      const select = document.getElementById('selectChave');
+      const alerta = document.getElementById('alertaSemChaves');
+      const resumo = document.getElementById('resumoCard');
+      const inputValor = document.getElementById('valor');
+      const solicitarBtn = document.getElementById('solicitar');
+
+      const valorSolicitado = document.getElementById('valorSolicitado');
+      const taxaFixa = document.getElementById('taxaFixa');
+      const taxaPerc = document.getElementById('taxaPerc');
+      const taxaPercLbl = document.getElementById('taxaPercLbl');
+      const valorLiquido = document.getElementById('valorLiquido');
+
+      function atualizarChaves(){
+        const chaves = carregarChaves();
+        select.innerHTML = '';
+        if (chaves.length === 0){
+          alerta.style.display = 'block';
+          select.disabled = true;
+        } else {
+          alerta.style.display = 'none';
+          select.disabled = false;
+          chaves.forEach(c => {
+            const opt = document.createElement('option');
+            opt.value = c.id; opt.textContent = c.value; select.appendChild(opt);
+          });
+        }
+      }
+
+      function atualizarResumo(){
+        const valor = parseFloat(inputValor.value) || 0;
+        if (valor > 0){
+          resumo.style.display = 'block';
+          const tPerc = (TAXA_PERCENTUAL/100) * valor;
+          const tTotal = TAXA_FIXA + tPerc;
+          const liquido = Math.max(0, valor - tTotal);
+          valorSolicitado.textContent = formatar(valor);
+          taxaFixa.textContent = `- ${formatar(TAXA_FIXA)}`;
+          taxaPercLbl.textContent = TAXA_PERCENTUAL;
+          taxaPerc.textContent = `- ${formatar(tPerc)}`;
+          valorLiquido.textContent = formatar(liquido);
+          solicitarBtn.disabled = select.disabled || !select.value || valor <= 0;
+        } else {
+          resumo.style.display = 'none';
+          solicitarBtn.disabled = true;
+        }
+      }
+
+      inputValor.addEventListener('input', atualizarResumo);
+      select.addEventListener('change', atualizarResumo);
+
+      solicitarBtn.addEventListener('click', function(){
+        solicitarBtn.innerHTML = '<i data-lucide="loader-2" class="w-5 h-5 mr-2 animate-spin"></i> Processando...';
+        solicitarBtn.disabled = true; lucide.createIcons();
+        setTimeout(() => { window.location.href = 'react-saldo.html'; }, 1500);
+      });
+
+      atualizarChaves();
+      atualizarResumo();
+    </script>
+
+    <style>
+      .animate-spin { animation: spin 1s linear infinite; }
+      @keyframes spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }
+      .bg-yellow-50 { background-color: hsl(45, 100%, 97%);} .text-yellow-900{ color: hsl(45, 100%, 20%);} .bg-blue-50{ background-color: hsl(212, 100%, 97%);} .text-blue-600{ color: hsl(212, 90%, 45%);} .text-green-600{ color: hsl(142, 76%, 36%);} 
+    </style>
+  </body>
+</html>

--- a/static/react-saque.html
+++ b/static/react-saque.html
@@ -13,14 +13,19 @@
         <div class="container mx-auto px-6 py-4">
           <div class="flex items-center justify-between">
             <a href="react-index.html" class="flex items-center space-x-2">
-              <div class="w-8 h-8 bg-primary rounded-lg flex items-center justify-center">
+              <div
+                class="w-8 h-8 bg-primary rounded-lg flex items-center justify-center"
+              >
                 <i data-lucide="zap" class="w-5 h-5 text-white"></i>
               </div>
               <span class="text-xl font-bold text-gray-900">TalentHub</span>
             </a>
 
             <div class="flex items-center space-x-4">
-              <button class="button button-ghost button-sm" onclick="history.back()">
+              <button
+                class="button button-ghost button-sm"
+                onclick="history.back()"
+              >
                 <i data-lucide="arrow-left" class="w-4 h-4 mr-2"></i>
                 Voltar
               </button>
@@ -36,7 +41,9 @@
       <div class="container mx-auto px-6 py-8 max-w-2xl">
         <div class="mb-8">
           <h1 class="text-3xl font-bold text-gray-900 mb-2">Solicitar Saque</h1>
-          <p class="text-gray-600">Escolha sua chave PIX, informe o valor e confira as taxas.</p>
+          <p class="text-gray-600">
+            Escolha sua chave PIX, informe o valor e confira as taxas.
+          </p>
         </div>
 
         <div class="space-y-6">
@@ -48,15 +55,28 @@
               </h3>
             </div>
             <div class="card-content space-y-3">
-              <div id="alertaSemChaves" class="p-4 border rounded-lg bg-yellow-50 text-yellow-900" style="display:none">
-                Você ainda não tem chaves cadastradas. <a href="react-cadastro-chave-pix.html" class="underline font-medium">Cadastrar chave PIX</a>
+              <div
+                id="alertaSemChaves"
+                class="p-4 border rounded-lg bg-yellow-50 text-yellow-900"
+                style="display: none"
+              >
+                Você ainda não tem chaves cadastradas.
+                <a
+                  href="react-cadastro-chave-pix.html"
+                  class="underline font-medium"
+                  >Cadastrar chave PIX</a
+                >
               </div>
               <div>
                 <label class="label">Selecionar chave</label>
                 <select id="selectChave" class="input mt-1"></select>
               </div>
               <div>
-                <a href="react-cadastro-chave-pix.html" class="button button-outline mt-2">Cadastrar nova chave</a>
+                <a
+                  href="react-cadastro-chave-pix.html"
+                  class="button button-outline mt-2"
+                  >Cadastrar nova chave</a
+                >
               </div>
             </div>
           </div>
@@ -72,14 +92,24 @@
               <div>
                 <label for="valor" class="label">Digite o valor</label>
                 <div class="relative mt-1">
-                  <span class="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500">R$</span>
-                  <input id="valor" type="number" min="1" step="0.01" class="input pl-10 text-lg" placeholder="0,00" />
+                  <span
+                    class="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500"
+                    >R$</span
+                  >
+                  <input
+                    id="valor"
+                    type="number"
+                    min="1"
+                    step="0.01"
+                    class="input pl-10 text-lg"
+                    placeholder="0,00"
+                  />
                 </div>
               </div>
             </div>
           </div>
 
-          <div class="card" id="resumoCard" style="display:none">
+          <div class="card" id="resumoCard" style="display: none">
             <div class="card-header">
               <h3 class="card-title">Resumo do Saque</h3>
             </div>
@@ -93,7 +123,9 @@
                 <span class="text-red-600" id="taxaFixa">- R$ 0,00</span>
               </div>
               <div class="flex justify-between">
-                <span class="text-gray-600">Taxa percentual (<span id="taxaPercLbl">0</span>%)</span>
+                <span class="text-gray-600"
+                  >Taxa percentual (<span id="taxaPercLbl">0</span>%)</span
+                >
                 <span class="text-red-600" id="taxaPerc">- R$ 0,00</span>
               </div>
               <hr />
@@ -103,9 +135,16 @@
               </div>
               <div class="flex items-start gap-2 p-3 bg-blue-50 rounded-lg">
                 <i data-lucide="info" class="w-4 h-4 text-blue-600 mt-0.5"></i>
-                <p class="text-sm text-blue-900">As taxas são aplicadas ao valor solicitado e o líquido será enviado para a chave selecionada.</p>
+                <p class="text-sm text-blue-900">
+                  As taxas são aplicadas ao valor solicitado e o líquido será
+                  enviado para a chave selecionada.
+                </p>
               </div>
-              <button id="solicitar" class="button button-primary w-full h-12 text-lg" disabled>
+              <button
+                id="solicitar"
+                class="button button-primary w-full h-12 text-lg"
+                disabled
+              >
                 <i data-lucide="wallet" class="w-5 h-5 mr-2"></i>
                 Solicitar saque
               </button>
@@ -117,47 +156,57 @@
 
     <script>
       lucide.createIcons();
-      const STORAGE_KEY = 'pixKeys';
+      const STORAGE_KEY = "pixKeys";
       const TAXA_FIXA = 0;
       const TAXA_PERCENTUAL = 0;
 
-      function carregarChaves(){ try { return JSON.parse(localStorage.getItem(STORAGE_KEY)) || []; } catch { return []; } }
+      function carregarChaves() {
+        try {
+          return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+        } catch {
+          return [];
+        }
+      }
 
-      function formatar(valor){ return `R$ ${valor.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}`; }
+      function formatar(valor) {
+        return `R$ ${valor.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}`;
+      }
 
-      const select = document.getElementById('selectChave');
-      const alerta = document.getElementById('alertaSemChaves');
-      const resumo = document.getElementById('resumoCard');
-      const inputValor = document.getElementById('valor');
-      const solicitarBtn = document.getElementById('solicitar');
+      const select = document.getElementById("selectChave");
+      const alerta = document.getElementById("alertaSemChaves");
+      const resumo = document.getElementById("resumoCard");
+      const inputValor = document.getElementById("valor");
+      const solicitarBtn = document.getElementById("solicitar");
 
-      const valorSolicitado = document.getElementById('valorSolicitado');
-      const taxaFixa = document.getElementById('taxaFixa');
-      const taxaPerc = document.getElementById('taxaPerc');
-      const taxaPercLbl = document.getElementById('taxaPercLbl');
-      const valorLiquido = document.getElementById('valorLiquido');
+      const valorSolicitado = document.getElementById("valorSolicitado");
+      const taxaFixa = document.getElementById("taxaFixa");
+      const taxaPerc = document.getElementById("taxaPerc");
+      const taxaPercLbl = document.getElementById("taxaPercLbl");
+      const valorLiquido = document.getElementById("valorLiquido");
 
-      function atualizarChaves(){
+      function atualizarChaves() {
         const chaves = carregarChaves();
-        select.innerHTML = '';
-        if (chaves.length === 0){
-          alerta.style.display = 'block';
+        select.innerHTML = "";
+        if (chaves.length === 0) {
+          alerta.style.display = "block";
           select.disabled = true;
         } else {
-          alerta.style.display = 'none';
+          alerta.style.display = "none";
           select.disabled = false;
-          chaves.forEach(c => {
-            const opt = document.createElement('option');
-            opt.value = c.id; opt.textContent = c.value; select.appendChild(opt);
+          chaves.forEach((c) => {
+            const opt = document.createElement("option");
+            opt.value = c.id;
+            opt.textContent = c.value;
+            select.appendChild(opt);
           });
         }
       }
 
-      function atualizarResumo(){
+      function atualizarResumo() {
         const valor = parseFloat(inputValor.value) || 0;
-        if (valor > 0){
-          resumo.style.display = 'block';
-          const tPerc = (TAXA_PERCENTUAL/100) * valor;
+        if (valor > 0) {
+          resumo.style.display = "block";
+          const tPerc = (TAXA_PERCENTUAL / 100) * valor;
           const tTotal = TAXA_FIXA + tPerc;
           const liquido = Math.max(0, valor - tTotal);
           valorSolicitado.textContent = formatar(valor);
@@ -165,20 +214,25 @@
           taxaPercLbl.textContent = TAXA_PERCENTUAL;
           taxaPerc.textContent = `- ${formatar(tPerc)}`;
           valorLiquido.textContent = formatar(liquido);
-          solicitarBtn.disabled = select.disabled || !select.value || valor <= 0;
+          solicitarBtn.disabled =
+            select.disabled || !select.value || valor <= 0;
         } else {
-          resumo.style.display = 'none';
+          resumo.style.display = "none";
           solicitarBtn.disabled = true;
         }
       }
 
-      inputValor.addEventListener('input', atualizarResumo);
-      select.addEventListener('change', atualizarResumo);
+      inputValor.addEventListener("input", atualizarResumo);
+      select.addEventListener("change", atualizarResumo);
 
-      solicitarBtn.addEventListener('click', function(){
-        solicitarBtn.innerHTML = '<i data-lucide="loader-2" class="w-5 h-5 mr-2 animate-spin"></i> Processando...';
-        solicitarBtn.disabled = true; lucide.createIcons();
-        setTimeout(() => { window.location.href = 'react-saldo.html'; }, 1500);
+      solicitarBtn.addEventListener("click", function () {
+        solicitarBtn.innerHTML =
+          '<i data-lucide="loader-2" class="w-5 h-5 mr-2 animate-spin"></i> Processando...';
+        solicitarBtn.disabled = true;
+        lucide.createIcons();
+        setTimeout(() => {
+          window.location.href = "react-saldo.html";
+        }, 1500);
       });
 
       atualizarChaves();
@@ -186,9 +240,32 @@
     </script>
 
     <style>
-      .animate-spin { animation: spin 1s linear infinite; }
-      @keyframes spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }
-      .bg-yellow-50 { background-color: hsl(45, 100%, 97%);} .text-yellow-900{ color: hsl(45, 100%, 20%);} .bg-blue-50{ background-color: hsl(212, 100%, 97%);} .text-blue-600{ color: hsl(212, 90%, 45%);} .text-green-600{ color: hsl(142, 76%, 36%);} 
+      .animate-spin {
+        animation: spin 1s linear infinite;
+      }
+      @keyframes spin {
+        from {
+          transform: rotate(0deg);
+        }
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      .bg-yellow-50 {
+        background-color: hsl(45, 100%, 97%);
+      }
+      .text-yellow-900 {
+        color: hsl(45, 100%, 20%);
+      }
+      .bg-blue-50 {
+        background-color: hsl(212, 100%, 97%);
+      }
+      .text-blue-600 {
+        color: hsl(212, 90%, 45%);
+      }
+      .text-green-600 {
+        color: hsl(142, 76%, 36%);
+      }
     </style>
   </body>
 </html>


### PR DESCRIPTION
## Purpose

The user requested the creation of PIX-related functionality following the same pattern as the deposit balance screen. They wanted:
1. A PIX key registration page supporting random, email, CPF/CNPJ, and phone number keys
2. A withdrawal page where users can select a PIX key, enter an amount, and request withdrawal with fee display
3. The random key generation button was later removed as requested
4. HTML versions of these pages saved to the static folder

## Code changes

### Frontend Components
- **Added `CadastroChavePix.tsx`**: PIX key registration page with form validation and key type selection (random, email, CPF/CNPJ, phone)
- **Added `Saque.tsx`**: Withdrawal page with PIX key selection, amount input, fee calculation, and transaction summary
- **Added routing**: New routes `/cadastro-chave-pix` and `/saque` in App.tsx

### PIX Management Library
- **Added `lib/pix.ts`**: Complete PIX key management system with:
  - TypeScript interfaces for PIX keys
  - Local storage operations (load, save, add, delete)
  - PIX key validation for different types
  - Random key generation utility

### Static HTML Pages
- **Added `static/react-cadastro-chave-pix.html`**: Standalone HTML version of PIX key registration
- **Added `static/react-saque.html`**: Standalone HTML version of withdrawal page with fee calculation

The implementation includes proper form validation, user feedback via toasts, and maintains consistency with the existing design patterns.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/be5e7639c5c348859bf374906d89b8b2/stellar-haven)

👀 [Preview Link](https://be5e7639c5c348859bf374906d89b8b2-stellar-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>be5e7639c5c348859bf374906d89b8b2</projectId>-->
<!--<branchName>stellar-haven</branchName>-->